### PR TITLE
Add autocomplete password

### DIFF
--- a/src/js/passwordReset.js
+++ b/src/js/passwordReset.js
@@ -54,10 +54,11 @@ class PasswordReset extends React.Component {
     }
   };
 
-  renderField = (label, type, stateKey, fromProps = false) => (
+  renderField = (label, type, stateKey, fromProps = false, autocomplete = "") => (
     <div className="d-flex flex-column">
       <label htmlFor={stateKey}>{label}</label>
       <input
+        autoComplete={autocomplete}
         className="p-2"
         disabled={fromProps}
         id={stateKey}
@@ -78,8 +79,8 @@ class PasswordReset extends React.Component {
           submitFn={this.resetPassword}
         >
           {this.renderField(localeText.email, "email", "email", true)}
-          {this.renderField(localeText.password, "password", "password")}
-          {this.renderField(localeText.confirm, "password", "passwordConfirmation")}
+          {this.renderField(localeText.password, "password", "password", false, "new-password")}
+          {this.renderField(localeText.confirm, "password", "passwordConfirmation", false, "new-password")}
           <div className="d-flex justify-content-end">
             <Button
               className="mt-3"

--- a/src/js/register.js
+++ b/src/js/register.js
@@ -99,10 +99,11 @@ class Register extends React.Component {
 
   /// Render Functions ///
 
-  renderField = (label, type, stateKey) => (
+  renderField = (label, type, stateKey, autocomplete = "") => (
     <div className="d-flex flex-column">
       <label htmlFor={stateKey}>{label}</label>
       <input
+        autoComplete={autocomplete}
         className="p-2"
         id={stateKey}
         onChange={e => this.setState({[stateKey]: e.target.value})}
@@ -145,7 +146,7 @@ class Register extends React.Component {
               selectLanguage={this.selectLanguage}
             />
           </div>
-          {this.renderField(localeText.username, "text", "username")}
+          {this.renderField(localeText.username, "text", "username", "username")}
           {this.renderField(localeText.email, "email", "email")}
           {this.renderField(localeText.fullName, "text", "fullName")}
           {this.renderField(localeText.institution, "text", "institution")}
@@ -158,8 +159,8 @@ class Register extends React.Component {
             ],
             "sector"
           )}
-          {this.renderField(localeText.password, "password", "password")}
-          {this.renderField(localeText.confirm, "password", "passwordConfirmation")}
+          {this.renderField(localeText.password, "password", "password", "new-password")}
+          {this.renderField(localeText.confirm, "password", "passwordConfirmation", "new-password")}
           <div className="d-flex justify-content-between align-items-center">
             <span style={{color: "red"}}>{localeText.allRequired}</span>
             <Button


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Allow form to auto complete the password when saved in browser when login. 

## Testing
User

#### Steps
1. Register a user with password and save that in browser 
2. Try to log in with that user 
#### Desired Outcome
When loging in, the browser should auto complete the password when entering the user name