### PR TITLE
SER-51 Separate Planet NICFI from other layers

### DIFF
--- a/resources/public/locale/en.json
+++ b/resources/public/locale/en.json
@@ -75,7 +75,13 @@
         "tierrasDeCom": "Afrocolombian Communal Lands",
         "resguardos": "Indigenous Reservations",
         "protectedAreas": "Protected Areas",
-        "NICFI": "Planet NICFI"
+        "NICFI": "Planet NICFI",
+        "satelliteTitle": "Updated Satellite Imagery",
+        "updateNICFI": "Update NICFI Layer",
+        "selectBand": "Select Band",
+        "visible": "Visible",
+        "infrared": "Infrared",
+        "selectTime": "Select Date"
     },
     "report": {
         "title": "Report Mines",

--- a/resources/public/locale/en.json
+++ b/resources/public/locale/en.json
@@ -62,8 +62,8 @@
         "updateMap": "Update map"
     },
     "layers": {
-        "title": "Select layers",
-        "nameLabel": "Layer name",
+        "title": "Select Layers",
+        "nameLabel": "Layer Name",
         "opacityLabel": "Opacity",
         "cMines": "Confirmed mines",
         "nMines": "New predictions",

--- a/resources/public/locale/es.json
+++ b/resources/public/locale/es.json
@@ -72,9 +72,15 @@
         "legalMines": "Títulos mineros",
         "otherAuthorizations": "Otras autorizaciones",
         "tierrasDeCom": "Consejos Comunitarios",
-        "resguardos": "Resguardos indígenas",
+        "resguardos": "Resguardos Indígenas",
         "protectedAreas": "Áreas Protegidas",
-        "NICFI": "Planet NICFI"
+        "NICFI": "Planet NICFI",
+        "satelliteTitle": "Imágenes Satelitales Actualizadas",
+        "updateNICFI": "Actualizar la capa NICFI",
+        "selectBand": "Seleccionar Banda",
+        "visible": "Visible",
+        "infrared": "Infrarroja",
+        "selectTime": "Seleccione Fecha"
     },
     "report": {
         "title": "Reportar minas",

--- a/src/js/components/NICFIControl.js
+++ b/src/js/components/NICFIControl.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import Button from "./Button";
 import Select from "./Select";
 
-export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
+export default function NICFIControl({ extraParams, setParams, nicfiLayers, layers }) {
   const [selectedTime, setTime] = useState("");
   const [selectedBand, setBand] = useState("");
   useEffect(() => {
@@ -17,7 +17,7 @@ export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
     <div className="flex flex-col">
       <Select
         id="time"
-        label="Select Time"
+        label={layers.selectTime}
         onChange={(e) => setTime(e.target.value)}
         options={nicfiLayers.map((time) => ({
           value: time,
@@ -26,7 +26,7 @@ export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
         value={selectedTime}
       />
       <div className="flex flex-col">
-        <label className="ml-0">Select Band</label>
+        <label className="ml-0">{layers.selectBand}</label>
         <div className="flex">
           <div>
             <input
@@ -34,17 +34,23 @@ export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
               id="visible"
               onChange={() => setBand("rgb")}
               type="radio"
+              style={{ cursor: "pointer" }}
             />
-            <label htmlFor="visible">Visible</label>
+            <label htmlFor="visible" style={{ cursor: "pointer", margin: 0 }}>
+              {layers.visible}
+            </label>
           </div>
-          <div className="pl-2">
+          <div className="pl-3">
             <input
               checked={selectedBand === "cir"}
               id="infrared"
               onChange={() => setBand("cir")}
               type="radio"
+              style={{ cursor: "pointer" }}
             />
-            <label htmlFor="infrared">Infrared</label>
+            <label htmlFor="infrared" style={{ cursor: "pointer", margin: 0 }}>
+              {layers.infrared}
+            </label>
           </div>
         </div>
       </div>
@@ -57,7 +63,7 @@ export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
           })
         }
       >
-        Update NICFI Layer
+        {layers.updateNICFI}
       </Button>
     </div>
   );

--- a/src/js/components/NICFIControl.js
+++ b/src/js/components/NICFIControl.js
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 
 import Button from "./Button";
 import Select from "./Select";
 
-export default function NICFIControl({extraParams, setParams, nicfiLayers}) {
+export default function NICFIControl({ extraParams, setParams, nicfiLayers }) {
   const [selectedTime, setTime] = useState("");
   const [selectedBand, setBand] = useState("");
   useEffect(() => {
@@ -14,16 +14,19 @@ export default function NICFIControl({extraParams, setParams, nicfiLayers}) {
   }, [extraParams]);
 
   return (
-    <div className="flex flex-col pl-3">
+    <div className="flex flex-col">
       <Select
         id="time"
         label="Select Time"
-        onChange={e => setTime(e.target.value)}
-        options={nicfiLayers.map(time => ({value: time, label: time.slice(34, time.length - 7)}))}
+        onChange={(e) => setTime(e.target.value)}
+        options={nicfiLayers.map((time) => ({
+          value: time,
+          label: time.slice(34, time.length - 7),
+        }))}
         value={selectedTime}
       />
       <div className="flex flex-col">
-        <label className="mb-0 mr-3">Select Band</label>
+        <label className="ml-0">Select Band</label>
         <div className="flex">
           <div>
             <input
@@ -32,9 +35,7 @@ export default function NICFIControl({extraParams, setParams, nicfiLayers}) {
               onChange={() => setBand("rgb")}
               type="radio"
             />
-            <label htmlFor="visible">
-            Visible
-            </label>
+            <label htmlFor="visible">Visible</label>
           </div>
           <div className="pl-2">
             <input
@@ -43,23 +44,20 @@ export default function NICFIControl({extraParams, setParams, nicfiLayers}) {
               onChange={() => setBand("cir")}
               type="radio"
             />
-            <label htmlFor="infrared">
-            Infrared
-            </label>
+            <label htmlFor="infrared">Infrared</label>
           </div>
         </div>
       </div>
       <Button
-        className="mt-4"
-        onClick={() => setParams(
-          "NICFI",
-          {
+        className="mt-2"
+        onClick={() =>
+          setParams("NICFI", {
             dataLayer: selectedTime,
-            band: selectedBand
-          }
-        )}
+            band: selectedBand,
+          })
+        }
       >
-          Update Map
+        Update NICFI Layer
       </Button>
     </div>
   );

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -1,15 +1,17 @@
 import React from "react";
 
-import {isString} from "lodash";
+import { isString } from "lodash";
 
-function Option({option, valueKey = "value", labelKey = "label", disabled}) {
+function Option({ option, valueKey = "value", labelKey = "label", disabled }) {
   const [value, label] = isString(option, "String")
     ? [option, option]
     : Array.isArray(option)
-      ? [option[0], option[1]]
-      : [option[valueKey], option[labelKey]];
+    ? [option[0], option[1]]
+    : [option[valueKey], option[labelKey]];
   return (
-    <option key={value} disabled={disabled} value={value}>{label}</option>
+    <option key={value} disabled={disabled} value={value}>
+      {label}
+    </option>
   );
 }
 
@@ -22,7 +24,7 @@ export default function Select({
   options = [],
   valueKey = "value",
   labelKey = "label",
-  defaultOption = ""
+  defaultOption = "",
 }) {
   return (
     <div className="w-100 mb-3">
@@ -33,15 +35,24 @@ export default function Select({
         id={id}
         onChange={onChange}
         value={value}
+        style={{ cursor: "pointer" }}
       >
-        <Option key="defaultOption" disabled labelKey={labelKey} option={[-1, defaultOption]} valueKey={valueKey}/>
+        <Option
+          key="defaultOption"
+          disabled
+          labelKey={labelKey}
+          option={[-1, defaultOption]}
+          valueKey={valueKey}
+        />
         {Array.isArray(options)
-          ? options.map((o, i) =>
-          /* eslint-disable-next-line react/no-array-index-key */
-            <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey}/>)
-          : Object.values(options).map((o, i) =>
-          /* eslint-disable-next-line react/no-array-index-key */
-            <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey}/>)}
+          ? options.map((o, i) => (
+              /* eslint-disable-next-line react/no-array-index-key */
+              <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey} />
+            ))
+          : Object.values(options).map((o, i) => (
+              /* eslint-disable-next-line react/no-array-index-key */
+              <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey} />
+            ))}
       </select>
     </div>
   );

--- a/src/js/components/ToolPanel.js
+++ b/src/js/components/ToolPanel.js
@@ -15,7 +15,8 @@ const PanelOuter = styled.div`
 
 const Title = styled.h2`
   border-bottom: 1px solid gray;
-  padding: .5rem;
+  font-weight: bold;
+  padding: 0.5rem;
 `;
 
 const Content = styled.div`
@@ -23,15 +24,11 @@ const Content = styled.div`
   padding: 1rem;
 `;
 
-export default function ToolPanel({title, children}) {
+export default function ToolPanel({ title, children }) {
   return (
     <PanelOuter>
-      <Title>
-        {title}
-      </Title>
-      <Content>
-        {children}
-      </Content>
+      <Title>{title}</Title>
+      <Content>{children}</Content>
     </PanelOuter>
   );
 }

--- a/src/js/home/LayersPanel.js
+++ b/src/js/home/LayersPanel.js
@@ -1,10 +1,10 @@
 import React from "react";
-import {MainContext} from "../components/PageLayout";
+import { MainContext } from "../components/PageLayout";
 
 import NICFIControl from "../components/NICFIControl";
 import ToolPanel from "../components/ToolPanel";
 
-import {startVisible, availableLayers} from "../constants";
+import { startVisible, availableLayers } from "../constants";
 
 export default class LayersPanel extends React.Component {
   constructor(props) {
@@ -12,36 +12,41 @@ export default class LayersPanel extends React.Component {
 
     this.state = {
       visible: null,
-      opacity: null
+      opacity: null,
     };
   }
 
   componentDidMount() {
     this.setState({
-      visible: availableLayers.reduce((acc, cur) => ({...acc, [cur]: startVisible.includes(cur) || false}), {}),
-      opacity: availableLayers.reduce((acc, cur) => ({...acc, [cur]: 100}), {})
+      visible: availableLayers.reduce(
+        (acc, cur) => ({ ...acc, [cur]: startVisible.includes(cur) || false }),
+        {}
+      ),
+      opacity: availableLayers.reduce((acc, cur) => ({ ...acc, [cur]: 100 }), {}),
     });
   }
 
   setVisible = (name, layerVisible) => {
-    const {visible} = this.state;
-    const {theMap} = this.props;
+    const { visible } = this.state;
+    const { theMap } = this.props;
     theMap.setLayoutProperty(name, "visibility", layerVisible ? "visible" : "none");
-    this.setState({visible: {...visible, [name]: layerVisible}});
+    this.setState({ visible: { ...visible, [name]: layerVisible } });
   };
 
   setOpacity = (name, newOpacity) => {
-    const {opacity} = this.state;
-    const {theMap} = this.props;
+    const { opacity } = this.state;
+    const { theMap } = this.props;
     theMap.setPaintProperty(name, "raster-opacity", newOpacity / 100);
     this.setState({
-      opacity: {...opacity, [name]: newOpacity}
+      opacity: { ...opacity, [name]: newOpacity },
     });
   };
 
-  renderControl = name => {
-    const {opacity, visible} = this.state;
-    const {localeText: {layers}} = this.context;
+  renderControl = (name) => {
+    const { opacity, visible } = this.state;
+    const {
+      localeText: { layers },
+    } = this.context;
     const layerVisible = visible[name];
     return (
       <div key={name} className="d-flex justify-content-between align-items-center mb-2">
@@ -52,14 +57,16 @@ export default class LayersPanel extends React.Component {
             onChange={() => this.setVisible(name, !layerVisible)}
             type="checkbox"
           />
-          <label htmlFor={"label-" + name} style={{margin: "0 0 3px 0"}}>{layers[name]}</label>
+          <label htmlFor={"label-" + name} style={{ margin: "0 0 3px 0" }}>
+            {layers[name]}
+          </label>
         </div>
         <input
           className="p-0 m-0"
           max="100"
           min="0"
-          onChange={e => this.setOpacity(name, parseInt(e.target.value))}
-          style={{width: "40%"}}
+          onChange={(e) => this.setOpacity(name, parseInt(e.target.value))}
+          style={{ width: "40%" }}
           type="range"
           value={opacity[name]}
         />
@@ -67,30 +74,50 @@ export default class LayersPanel extends React.Component {
     );
   };
 
-  renderControlWrapper = name => (name === "NICFI"
-    ? (
-      <div key={name} className="d-flex flex-column">
-        {this.renderControl(name)}
+  renderHeading = (layers) => (
+    <>
+      <div className="d-flex justify-content-between mb-0">
+        <label style={{ fontWeight: "bold", margin: "0 .25rem 0 0" }}>{layers.nameLabel}</label>
+        <label style={{ fontWeight: "bold", margin: "0 .25rem", width: "40%" }}>
+          {layers.opacityLabel}
+        </label>
+      </div>
+      <hr style={{ marginBottom: "0.5rem" }}></hr>
+    </>
+  );
+
+  renderNICFISection = () => (
+    <>
+      <label style={{ fontWeight: "bold", margin: "0 .25rem 0 0" }}>
+        Updated Satellite Imagery
+      </label>
+      <hr style={{ marginBottom: "0.5rem" }}></hr>
+      <div className="d-flex flex-column">
+        {this.renderControl("NICFI")}
         <NICFIControl
           extraParams={this.props.extraParams}
           nicfiLayers={this.props.nicfiLayers}
           setParams={this.props.setParams}
         />
       </div>
-    ) : this.renderControl(name));
+    </>
+  );
 
   render() {
-    const {opacity, visible} = this.state;
-    const {localeText: {layers}} = this.context;
+    const { opacity, visible } = this.state;
+    const {
+      localeText: { layers },
+    } = this.context;
     return (
       <ToolPanel title={layers.title}>
-        <div className="d-flex justify-content-between mb-2">
-          <label style={{margin: "0 .25rem"}}>{layers.nameLabel}</label>
-          <div style={{width: "40%"}}>
-            <label style={{margin: "0 .25rem"}}>{layers.opacityLabel}</label>
-          </div>
-        </div>
-        {opacity && visible && availableLayers.map(l => this.renderControlWrapper(l))}
+        {this.renderHeading(layers)}
+        {opacity &&
+          visible &&
+          availableLayers.map((layerName) =>
+            layerName === "NICFI" ? "" : this.renderControl(layerName)
+          )}
+        <br></br>
+        {opacity && visible && this.renderNICFISection("NICFI")}
       </ToolPanel>
     );
   }

--- a/src/js/home/LayersPanel.js
+++ b/src/js/home/LayersPanel.js
@@ -56,8 +56,9 @@ export default class LayersPanel extends React.Component {
             id={"label-" + name}
             onChange={() => this.setVisible(name, !layerVisible)}
             type="checkbox"
+            style={{ cursor: "pointer" }}
           />
-          <label htmlFor={"label-" + name} style={{ margin: "0 0 3px 0" }}>
+          <label htmlFor={"label-" + name} style={{ cursor: "pointer", margin: "0 0 3px 0" }}>
             {layers[name]}
           </label>
         </div>
@@ -66,7 +67,7 @@ export default class LayersPanel extends React.Component {
           max="100"
           min="0"
           onChange={(e) => this.setOpacity(name, parseInt(e.target.value))}
-          style={{ width: "40%" }}
+          style={{ cursor: "pointer", width: "40%" }}
           type="range"
           value={opacity[name]}
         />
@@ -86,11 +87,9 @@ export default class LayersPanel extends React.Component {
     </>
   );
 
-  renderNICFISection = () => (
+  renderNICFISection = (layers) => (
     <>
-      <label style={{ fontWeight: "bold", margin: "0 .25rem 0 0" }}>
-        Updated Satellite Imagery
-      </label>
+      <label style={{ fontWeight: "bold", margin: "0 .25rem 0 0" }}>{layers.satelliteTitle}</label>
       <hr style={{ marginBottom: "0.5rem" }}></hr>
       <div className="d-flex flex-column">
         {this.renderControl("NICFI")}
@@ -98,6 +97,7 @@ export default class LayersPanel extends React.Component {
           extraParams={this.props.extraParams}
           nicfiLayers={this.props.nicfiLayers}
           setParams={this.props.setParams}
+          layers={layers}
         />
       </div>
     </>
@@ -117,7 +117,7 @@ export default class LayersPanel extends React.Component {
             layerName === "NICFI" ? "" : this.renderControl(layerName)
           )}
         <br></br>
-        {opacity && visible && this.renderNICFISection("NICFI")}
+        {opacity && visible && this.renderNICFISection(layers)}
       </ToolPanel>
     );
   }


### PR DESCRIPTION
## Purpose
Separates the Planet NICFI layer from the other layers on the UI by placing it in its own section. Added some small UI tweaks and cleaned up some code in `LayersPanel.js`.

## Related Issues
Closes SER-51

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `COM-### Did something here`)
- [x] Code passes linter rules (`npx eslint "src/js/**"`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
All layers should work normally. 

## Screenshots
### Before
![Screenshot from 2022-07-18 16-15-39](https://user-images.githubusercontent.com/40574170/179632659-14b4b55e-60d5-41b4-8396-a2b57047ccab.png)

### After
![Screenshot from 2022-07-18 16-12-19](https://user-images.githubusercontent.com/40574170/179632681-e89215dd-d020-4f20-b4f8-0914a47c9d07.png)

