### PR TITLE
SER-100 Fix dev git tags 403 issue

### DIFF
--- a/src/clj/comimo/git.clj
+++ b/src/clj/comimo/git.clj
@@ -14,9 +14,11 @@
 ;; Private Fns
 
 (defn- get-all-tags []
-  (let [{:keys [status body]} (client/get tags-url)]
-    (when (= 200 status)
-      (json/read-str body :key-fn keyword))))
+  (try
+    (let [{:keys [status body]} (client/get tags-url)]
+      (when (= 200 status)
+        (json/read-str body :key-fn keyword)))
+    (catch Exception _)))
 
 (defn- latest-prod-tag []
   (->> (get-all-tags)


### PR DESCRIPTION
## Purpose

Handle when git server returns 403 when pulling for repo tags (cap of # requests for an address)

## Related Issues

Closes SER-100
