### PR TITLE
SER-98 Fix an issue where there were multiple plot labels in each plot

### DIFF
--- a/src/js/collect/NavBar.js
+++ b/src/js/collect/NavBar.js
@@ -49,7 +49,7 @@ export default function NavBar({
 
   const currentPlotNumber = () => {
     let num = plotNumberToGo || currentPlotId - shiftPlotId + 1;
-    return num <= 0 ? 1 : num;
+    return num <= 0 ? "1" : `${num}`;
   };
 
   const renderGoToPlot = () => (


### PR DESCRIPTION
## Purpose
Fixes an issue where zooming in on a plot label would then show duplicate plot labels. To fix this, I added a new source specifically for each plot label. Also fixes an error message that would show up when collecting by casting a number to a string for the plot number input.

## Related Issues
Closes SER-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules (`npm run lint`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Validation > Plot Label 

#### Role
User

#### Steps
1. Create a new project 
2. Go to collect on the project
3. Select a specific plot number
4. Zoom all the way in on that plot's label

#### Desired Outcome
The plot label should only appear once when you zoom in and out.

## Screenshots
![Screenshot from 2022-08-09 12-49-28](https://user-images.githubusercontent.com/40574170/183750121-73538757-0ddb-452f-b8e5-04f349c7a772.png)

