### PR TITLE
SER-248 Add selected state to IconButtons

### DIFF
--- a/src/js/components/IconButton.jsx
+++ b/src/js/components/IconButton.jsx
@@ -5,11 +5,11 @@ import { THEME } from "../constants";
 
 import SvgIcon from "./SvgIcon";
 
-// TODO: Incorporate selected state in order to use THEME.iconButtonSelected colors
-
 const StyledButton = styled.button`
-  background-color: ${THEME.iconButtonDefault.backgroundColor};
-  border-color: ${THEME.iconButtonDefault.borderColor};
+  background-color: ${({ $active }) =>
+    $active ? THEME.iconButtonSelected.backgroundColor : THEME.iconButtonDefault.backgroundColor};
+  border-color: ${({ $active }) =>
+    $active ? THEME.iconButtonSelected.borderColor : THEME.iconButtonDefault.borderColor};
   border-radius: 50%;
   border-style: solid;
   border-width: 1px;


### PR DESCRIPTION
## Purpose
Adds a selected state style to the IconButtons

## Related Issues
Closes SER-248

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules (`npm run lint`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
Selecting an IconButton on the side toolbar should change its styling (see screenshot below). 

## Screenshots
![Screenshot from 2022-08-17 14-59-43](https://user-images.githubusercontent.com/40574170/185251219-f6ab5bd8-512b-4f36-a947-2ff0921fdcf4.png)

