### PR TITLE
SER-249 Create an icon + text button component

### DIFF
--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -3,54 +3,58 @@ import Button from "./Button";
 import styled from "@emotion/styled";
 
 import LanguageSelector from "./LanguageSelector";
-import IconButton from "./IconButton";
+import IconTextButton from "./IconTextButton";
 
 const TitleBar = styled.div`
-  width: 100%;
   background: var(--gray-1);
-  text-align: center;
-  padding: 5px;
-  height: 3.5rem;
   display: flex;
+  height: 60px;
   justify-content: space-between;
+  text-align: center;
+  width: 100%;
 `;
 
 const Search = styled.div`
+  display: flex;
+  justify-content: center;
   flex: 1;
 `;
 
 const Logo = styled.div`
-  display: relative;
   align-items: center;
-  justify-content: center;
-  flex-direction: column;
+  display: relative;
   flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding: 5px 0;
 `;
 
 const LogoImg = styled.img`
-  width: 130px;
-  height: 43px;
   cursor: pointer;
+  height: 43px;
+  width: 130px;
 `;
 
 const LogoGitVersion = styled.span`
-  position: relative;
-  left: -90px;
   bottom: 0px;
   color: var(--white);
-  text-align: left;
   font-size: 12px;
+  left: -90px;
   letter-spacing: 0px;
+  position: relative;
+  text-align: left;
 `;
 
 const UserSettings = styled.div`
+  display: flex;
   flex: 1;
+  justify-content: space-around;
 `;
 
 const LoggedInUserPanel = styled.div`
   align-items: center;
-  display: flex;
   cursor: pointer;
+  display: flex;
 `;
 
 const LoggedInUsername = styled.span`
@@ -76,10 +80,21 @@ export default function Header({
 }) {
   return (
     <TitleBar id="title-bar">
-      <Search>
-        <button>test</button>
+      <Search id="header-search">
+        {/* TODO: onClick should open up the Search functionality
+        TODO: have an active state that we can pass to IconTextButton */}
+        <IconTextButton
+          active={false}
+          clickHandler={() => window.alert("place holder for search functionality")}
+          hasBackground={true}
+          icon="search"
+          iconSize="26px"
+          invertBorderRadius={true}
+          text="Search"
+          tooltip="Placeholder Search ToolTip"
+        />
       </Search>
-      <Logo>
+      <Logo id="header-logo">
         <LogoImg
           alt="app-logo"
           onClick={() => window.location.assign("/")}
@@ -89,37 +104,33 @@ export default function Header({
         <LogoGitVersion>prod-2022-08-01</LogoGitVersion>
         {/* <LogoGitVersion>{version && `Version: ${version}`}</LogoGitVersion> */}
       </Logo>
-      <UserSettings>
-        <div
-          id="user-panel"
-          style={{
-            alignItems: "center",
-            display: "flex",
-            position: "fixed",
-            right: "56px",
-            top: "10px",
-            zIndex: 1000,
-          }}
-        >
-          {username ? (
-            // TODO: onClick should open up the menu with the Account Settings, Notifications, and Subscribed Muncipalities buttons
-            <LoggedInUserPanel onClick={() => window.location.assign("/user-account")}>
-              <IconButton icon="user" size="26px" tooltip="place holder tooltip" />
-              <LoggedInUsername>{username}</LoggedInUsername>
-            </LoggedInUserPanel>
-          ) : (
-            // TODO: Make this a styled component
-            <Button
-              style={{ margin: "0.25rem" }}
-              onClick={() => {
-                window.location.assign("/login");
-              }}
-            >
-              {localeText.users?.login}
-            </Button>
-          )}
-          <LanguageSelector selectedLanguage={selectedLanguage} selectLanguage={selectLanguage} />
-        </div>
+      <UserSettings id="user-settings">
+        {username ? (
+          // TODO: onClick should open up the menu with the Account Settings, Notifications, and Subscribed Muncipalities buttons
+          // TODO: have an active state that we can pass to IconTextButton
+          <LoggedInUserPanel>
+            <IconTextButton
+              active={false}
+              clickHandler={() => window.location.assign("/user-account")}
+              hasBackground={false}
+              icon="user"
+              iconSize="26px"
+              text={username}
+              tooltip="Placeholder ToolTip"
+            />
+          </LoggedInUserPanel>
+        ) : (
+          // TODO: Updte the Button component to use the new styles
+          <Button
+            style={{ margin: "0.25rem" }}
+            onClick={() => {
+              window.location.assign("/login");
+            }}
+          >
+            {localeText.users?.login}
+          </Button>
+        )}
+        <LanguageSelector selectedLanguage={selectedLanguage} selectLanguage={selectLanguage} />
       </UserSettings>
     </TitleBar>
   );

--- a/src/js/components/IconButton.jsx
+++ b/src/js/components/IconButton.jsx
@@ -13,6 +13,7 @@ const StyledButton = styled.button`
   border-radius: 50%;
   border-style: solid;
   border-width: 1px;
+  cursor: pointer;
   height: fit-content;
   margin: 5px 0;
   padding: 0;
@@ -31,7 +32,7 @@ const SvgContainer = styled.div`
   padding: 6px;
 `;
 
-function IconButton({ icon, parentClass, clickHandler, tooltip, active, size }) {
+function IconButton({ active, icon, parentClass, clickHandler, size, tooltip }) {
   return (
     <StyledButton
       $active={active}

--- a/src/js/components/IconTextButton.jsx
+++ b/src/js/components/IconTextButton.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { THEME } from "../constants";
 
@@ -16,9 +16,11 @@ const Container = styled.button`
   height: 100%;
   justify-content: space-between;
   text-decoration: ${({ $active }) => ($active ? "underline" : "none")};
+  transition: text-decoration 0.15s ease-in-out;
 
   &:hover {
     text-decoration: underline;
+  }
 `;
 
 const Label = styled.span`
@@ -40,16 +42,19 @@ function IconTextButton({
   text,
   tooltip,
 }) {
+  const [hover, setHover] = useState(false);
+
   return (
     <Container
       $background={hasBackground}
       $invertBorderRadius={invertBorderRadius || false}
       onClick={clickHandler}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
       title={tooltip}
     >
-      {/* TODO: The active state is not working when passing it here to IconButton, not sure why */}
-      <IconButton $active={active} icon={icon} size={iconSize} />
-      <Label $active={active}>{text}</Label>
+      <IconButton active={hover || active} icon={icon} size={iconSize} />
+      <Label $active={hover}>{text}</Label>
     </Container>
   );
 }

--- a/src/js/components/IconTextButton.jsx
+++ b/src/js/components/IconTextButton.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { THEME } from "../constants";
+
+import IconButton from "./IconButton";
+
+const OuterButton = styled.button`
+  align-items: center;
+  background-color: ${({ $background }) => ($background ? "#434343" : "transparent")};
+  box-shadow: 0px 3px 6px #00000029;
+  border-radius: ${({ $invertBorderRadius }) =>
+    $invertBorderRadius ? "6px 6px 0px 0px" : "0px 0px 6px 6px"};
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  justify-content: space-between;
+`;
+
+const ButtonLabel = styled.span`
+  color: var(--white);
+  font-size: 18px;
+  font-weight: var(--unnamed-font-weight-medium);
+  letter-spacing: 0px;
+  padding: 0 0.5rem;
+  text-align: left;
+  text-decoration: ${({ $active }) => ($active ? "underline" : "none")};
+
+  // TODO: The icon and the label should both have the same hover state when
+  // the outer div is hovered over
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+function IconTextButton({
+  active,
+  clickHandler,
+  hasBackground,
+  icon,
+  iconSize,
+  invertBorderRadius,
+  text,
+  tooltip,
+}) {
+  return (
+    <OuterButton
+      $background={hasBackground}
+      $invertBorderRadius={invertBorderRadius || false}
+      onClick={clickHandler}
+      title={tooltip}
+    >
+      {/* TODO: The active state is not working when passing it here to IconButton, not sure why */}
+      <IconButton $active={active} icon={icon} size={iconSize} />
+      <ButtonLabel $active={active}>{text}</ButtonLabel>
+    </OuterButton>
+  );
+}
+
+export default IconTextButton;

--- a/src/js/components/IconTextButton.jsx
+++ b/src/js/components/IconTextButton.jsx
@@ -4,32 +4,30 @@ import { THEME } from "../constants";
 
 import IconButton from "./IconButton";
 
-const OuterButton = styled.button`
+const Container = styled.button`
   align-items: center;
   background-color: ${({ $background }) => ($background ? "#434343" : "transparent")};
   box-shadow: 0px 3px 6px #00000029;
   border-radius: ${({ $invertBorderRadius }) =>
     $invertBorderRadius ? "6px 6px 0px 0px" : "0px 0px 6px 6px"};
+  color: var(--white);
   cursor: pointer;
   display: flex;
   height: 100%;
   justify-content: space-between;
+  text-decoration: ${({ $active }) => ($active ? "underline" : "none")};
+
+  &:hover {
+    text-decoration: underline;
 `;
 
-const ButtonLabel = styled.span`
+const Label = styled.span`
   color: var(--white);
   font-size: 18px;
   font-weight: var(--unnamed-font-weight-medium);
   letter-spacing: 0px;
   padding: 0 0.5rem;
   text-align: left;
-  text-decoration: ${({ $active }) => ($active ? "underline" : "none")};
-
-  // TODO: The icon and the label should both have the same hover state when
-  // the outer div is hovered over
-  &:hover {
-    text-decoration: underline;
-  }
 `;
 
 function IconTextButton({
@@ -43,7 +41,7 @@ function IconTextButton({
   tooltip,
 }) {
   return (
-    <OuterButton
+    <Container
       $background={hasBackground}
       $invertBorderRadius={invertBorderRadius || false}
       onClick={clickHandler}
@@ -51,8 +49,8 @@ function IconTextButton({
     >
       {/* TODO: The active state is not working when passing it here to IconButton, not sure why */}
       <IconButton $active={active} icon={icon} size={iconSize} />
-      <ButtonLabel $active={active}>{text}</ButtonLabel>
-    </OuterButton>
+      <Label $active={active}>{text}</Label>
+    </Container>
   );
 }
 


### PR DESCRIPTION
## Purpose
Adds a new `IconTextButton` component which combines the `IconButton` component with a text label to match the styling in Andrea's prototypes. You can optionally include a background as well as invert the border radius (as these things differ across Andrea's wireframes).

## Related Issues
Closes SER-249

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules (`npm run lint`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Screenshots
![Screenshot from 2022-08-18 10-44-51](https://user-images.githubusercontent.com/40574170/185460680-3d5ceb6f-a4d2-4e90-a290-72ee7655d671.png)

