### PR TITLE
SER-276 Fix the opacity slider on the collect page for NICFI layer

### DIFF
--- a/src/js/collect.jsx
+++ b/src/js/collect.jsx
@@ -26,7 +26,7 @@ import CollectDownload from "./collect/CollectDownload";
 import { jsonRequest } from "./utils";
 import { URLS } from "./constants";
 import { visiblePanelAtom, extraMapParamsAtom, showModalAtom } from "./home";
-import CollectMap from "./collect/CollectMap";
+import CollectMap, { collectMapAtom } from "./collect/CollectMap";
 import NavBar from "./collect/NavBar";
 
 const BarItem = styled.div`
@@ -61,6 +61,7 @@ export const currentPlotNumberAtom = atom(1);
 
 const CollectContent = ({ projectId }) => {
   // State
+  const collectMap = useAtomValue(collectMapAtom);
   const [visiblePanel, setVisiblePanel] = useAtom(visiblePanelAtom);
   const [showModal, setShowModal] = useAtom(showModalAtom);
   const [extraMapParams, setExtraMapParams] = useAtom(extraMapParamsAtom);
@@ -135,10 +136,10 @@ const CollectContent = ({ projectId }) => {
   const nextPlot = () => {
     const nextPlot = projectPlots.find((p) => p.id > currentPlotId) || projectPlots[0];
     if (currentPlotId === nextPlot.id) {
-      alert(t("home.noMorePlots"))
+      alert(t("home.noMorePlots"));
     } else {
       setCurrentPlotId(nextPlot.id);
-      setCurrentPlotNumber(nextPlot.id - projectPlots[0].id + 1)
+      setCurrentPlotNumber(nextPlot.id - projectPlots[0].id + 1);
     }
   };
 
@@ -153,12 +154,11 @@ const CollectContent = ({ projectId }) => {
     const plotsCopy = [...projectPlots].reverse();
     const prevPlot = plotsCopy.find((p) => p.id < currentPlotId) || plotsCopy[0];
     if (currentPlotId === prevPlot.id) {
-      alert(t("home.noMorePlots"))
+      alert(t("home.noMorePlots"));
     } else {
       setCurrentPlotId(prevPlot.id);
-      setCurrentPlotNumber(prevPlot.id - projectPlots[0].id + 1)
+      setCurrentPlotNumber(prevPlot.id - projectPlots[0].id + 1);
     }
-
   };
 
   const setPlotAnswer = async (answer) => {
@@ -206,6 +206,7 @@ const CollectContent = ({ projectId }) => {
               active={visiblePanel === "layers"}
               nicfiLayers={nicfiLayers}
               nicfiOnly={true}
+              theMap={collectMap}
             />
           </BarItem>
 

--- a/src/js/collect/CollectMap.jsx
+++ b/src/js/collect/CollectMap.jsx
@@ -13,8 +13,7 @@ import LatLngHud from "../components/LatLngHud";
 import { jsonRequest, toPrecision } from "../utils";
 import { attributions, THEME, URLS } from "../constants";
 
-
-const collectMapAtom = atom(null);
+export const collectMapAtom = atom(null);
 
 export default function CollectMap({ boundary, projectPlots, goToPlot, currentPlot }) {
   const [collectMap, setCollectMap] = useAtom(collectMapAtom);
@@ -142,8 +141,8 @@ export default function CollectMap({ boundary, projectPlots, goToPlot, currentPl
     answer === "Mina"
       ? THEME.mina.background
       : answer === "No Mina"
-        ? THEME.noMina.background
-        : THEME.map.unanswered;
+      ? THEME.noMina.background
+      : THEME.map.unanswered;
 
   const addPlots = () => {
     // Helper function to add plot sources
@@ -270,9 +269,9 @@ export default function CollectMap({ boundary, projectPlots, goToPlot, currentPl
       params == null
         ? url
         : url +
-        Object.entries(params)
-          .map(([k, v]) => `&${k}=${v}`)
-          .join("");
+          Object.entries(params)
+            .map(([k, v]) => `&${k}=${v}`)
+            .join("");
 
     setLayerUrl(layer, fullUrl);
   };

--- a/src/js/home.jsx
+++ b/src/js/home.jsx
@@ -46,6 +46,7 @@ export const processModal = (callBack, setShowModal) => {
 };
 
 function HomeContents() {
+  const homeMap = useAtomValue(homeMapAtom);
   const [visiblePanel, setVisiblePanel] = useAtom(visiblePanelAtom);
   const [selectedDates, setSelectedDates] = useAtom(selectedDatesAtom);
   const [homeMapPoupup, setHomeMapPoupup] = useAtom(mapPopupAtom);
@@ -145,9 +146,10 @@ function HomeContents() {
               text={t("home.layersTitle")}
             />
             <LayersPanel
-              nicfiOnly={false}
               active={visiblePanel === "layers"}
               nicfiLayers={nicfiLayers}
+              nicfiOnly={false}
+              theMap={homeMap}
             />
           </BarItem>
 

--- a/src/js/home/LayersPanel.jsx
+++ b/src/js/home/LayersPanel.jsx
@@ -9,7 +9,6 @@ import Divider from "../components/Divider";
 import HeaderLabel from "../components/HeaderLabel";
 import { extraMapParamsAtom } from "../home";
 import { startVisible, availableLayers, miningLayers, layerColors } from "../constants";
-import { homeMapAtom } from "./HomeMap";
 import { useTranslation } from "react-i18next";
 
 const Label = styled.label`
@@ -53,11 +52,10 @@ const LayerSlider = styled.input`
   }
 `;
 
-export default function LayersPanel({ nicfiLayers, active, nicfiOnly }) {
+export default function LayersPanel({ nicfiLayers, active, theMap, nicfiOnly }) {
   const [visible, setVisible] = useState(null);
   const [extraMapParams, setExtraMapParams] = useAtom(extraMapParamsAtom);
   const [opacity, setOpacity] = useState(null);
-  const homeMap = useAtomValue(homeMapAtom);
 
   const { t } = useTranslation();
 
@@ -80,12 +78,12 @@ export default function LayersPanel({ nicfiLayers, active, nicfiOnly }) {
   }, []);
 
   const setLayerVisible = (name, layerVisible) => {
-    homeMap.setLayoutProperty(name, "visibility", layerVisible ? "visible" : "none");
+    theMap.setLayoutProperty(name, "visibility", layerVisible ? "visible" : "none");
     setVisible({ ...visible, [name]: layerVisible });
   };
 
   const setLayerOpacity = (name, newOpacity) => {
-    homeMap.setPaintProperty(name, "raster-opacity", newOpacity / 100);
+    theMap.setPaintProperty(name, "raster-opacity", newOpacity / 100);
     setOpacity({ ...opacity, [name]: newOpacity });
   };
 


### PR DESCRIPTION
## Purpose
The opacity of the NICFI layer was not updating on the Collect page due to the `homeMap` being hard-coded in the `LayersPanel` component. This PR fixes that.

## Related Issues
Closes SER-276

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules (`npm run lint`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
The opacity slider should work on the layer panel on both the home and collect pages.
