### PR TITLE
SER-284 Update announcement banner logic and speed up collection

### DIFF
--- a/src/clj/comimo/views.clj
+++ b/src/clj/comimo/views.clj
@@ -41,7 +41,6 @@
                               (json/read-str)
                               (get src-file)))
 
-
         entrypoint-file (str "/" (get manifest "file"))
         asset-files     (mapv #(str/replace % #"^_" "/assets/")
                               (get manifest "imports"))]
@@ -121,45 +120,50 @@
      script-str]))
 
 (defn- announcement-banner []
-  (let [announcement (slurp "announcement.txt")]            ; TODO This will be moved to the front end for better UX.
-    [:div#banner {:style {:background-color "#f96841"
-                          :box-shadow       "3px 1px 4px 0 rgb(0, 0, 0, 0.25)"
-                          :color            "#ffffff"
-                          :display          (if (pos? (count announcement)) "block" "none")
-                          :margin           "0px"
-                          :padding          "5px"
+  (let [announcement (-> (slurp "announcement.txt")
+                         (str/split #"\n"))]            ; TODO This will be moved to the front end for better UX.
+    (when-not (empty? (first announcement))
+      [:div#banner {:style {:background-color "#f96841"
+                            :box-shadow       "3px 1px 4px 0 rgb(0, 0, 0, 0.25)"
+                            :color            "#ffffff"
+                            :display          (if (pos? (count announcement)) "block" "none")
+                            :margin           "0px"
+                            :padding          "5px"
+                            :position         "fixed"
+                            :text-align       "center"
+                            :top              "0"
+                            :right            "0"
+                            :left             "0"
+                            :width            "100vw"
+                            :z-index          "10000"}}
+       [:script {:type "text/javascript"}
+        "setTimeout (function () {document.getElementById ('banner') .style.display='none'}, 10000);"]
+       (map (fn [line]
+              [:p {:style {:font-size   "18px"
+                           :font-weight "bold"
+                           :margin      "0 30px 0 0"}
+                   :key   line}
+               line])
+            announcement)
+       [:button {:style  {:background-color "transparent"
+                          :border-color     "#ffffff"
+                          :border-radius    "50%"
+                          :border-style     "solid"
+                          :border-width     "2px"
+                          :cursor           "pointer"
+                          :display          "flex"
+                          :height           "25px"
+                          :padding          "0"
                           :position         "fixed"
-                          :text-align       "center"
-                          :top              "0"
-                          :right            "0"
-                          :left             "0"
-                          :width            "100vw"
-                          :z-index          "10000"}}
-     [:script {:type "text/javascript"}
-      "setTimeout (function () {document.getElementById ('banner') .style.display='none'}, 10000);"]
-     [:p {:style {:font-size   "18px"
-                  :font-weight "bold"
-                  :margin      "0 30px 0 0"}}
-      announcement]
-     [:button {:style  {:background-color "transparent"
-                        :border-color     "#ffffff"
-                        :border-radius    "50%"
-                        :border-style     "solid"
-                        :border-width     "2px"
-                        :cursor           "pointer"
-                        :display          "flex"
-                        :height           "25px"
-                        :padding          "0"
-                        :position         "fixed"
-                        :right            "10px"
-                        :top              "5px"
-                        :width            "25px"}
-               :onClick "document.getElementById('banner').style.display='none'"}
-      [:svg {:viewBox "0 0 48 48" :fill "#ffffff"}
-       [:path {:d "M38 12.83l-2.83-2.83-11.17 11.17-11.17-11.17-2.83 2.83 11.17 11.17-11.17 11.17 2.83 2.83
-                     11.17-11.17 11.17 11.17 2.83-2.83-11.17-11.17z"}]]]]))
+                          :right            "10px"
+                          :top              "5px"
+                          :width            "25px"}
+                 :onClick "document.getElementById('banner').style.display='none'"}
+        [:svg {:viewBox "0 0 48 48" :fill "#ffffff"}
+         [:path {:d "M38 12.83l-2.83-2.83-11.17 11.17-11.17-11.17-2.83 2.83 11.17 11.17-11.17 11.17 2.83 2.83
+                     11.17-11.17 11.17 11.17 2.83-2.83-11.17-11.17z"}]]]])))
 
-;;  TODO add no caching? 
+;;  TODO add no caching?
 (defn render-page [uri]
   (fn [request]
     (let [page             (uri->page uri)

--- a/src/js/collect/CollectMap.jsx
+++ b/src/js/collect/CollectMap.jsx
@@ -104,7 +104,11 @@ export default function CollectMap({ boundary, projectPlots, goToPlot, currentPl
       }
     } else if (type === "bbox") {
       try {
-        collectMap.fitBounds(arg, { padding: { top: 16, bottom: 94, left: 16, right: 16 } });
+        collectMap.fitBounds(arg, {
+          padding: { top: 16, bottom: 94, left: 16, right: 16 },
+          linear: false,
+          speed: 2.75,
+        });
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
## Purpose
Adds logic to the announcement banner so that it can be multiple lines. Speeds up the `flyTo` functionality on the collect page for quicker collection.

## Related Issues
Closes SER-284

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules (`npm run lint`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
 

## Screenshots 
![Screenshot from 2022-09-22 16-11-35](https://user-images.githubusercontent.com/40574170/191868911-2ca75653-4712-4bbb-a0d9-7938bc3aa52e.png)

