### PR TITLE
SER-301 Utils functions appear to be crashing the site

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -31,8 +31,13 @@ export function jsonRequest(url, jsonBody = {}, method = "POST") {
 }
 
 export function titleCase(str) {
-  return str
-    .split(" ")
-    .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
-    .join(" ");
+  return (
+    str &&
+    str?.length > 0 &&
+    str
+      .trim()
+      .split(" ")
+      .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ")
+  );
 }


### PR DESCRIPTION
## Purpose

To not crash when calling titleCase in validation panel when regions happen to have empty strings or maybe undefined for whatever reason. 

## Related Issues

Closes SER-###

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)
