### PR TITLE
SER-302 Some small email fixes

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -3,12 +3,12 @@
                 :dbname   "comimo"
                 :user     "comimo"
                 :password "comimo"}
- :mail         {:host     "smtp.gmail.com"
-                :user     ""
-                :pass     ""
-                :tls      true
-                :port     587
-                :base-url "https://my.domain/"
+ :mail         {:host           "smtp.gmail.com"
+                :user           ""
+                :pass           ""
+                :tls            true
+                :port           587
+                :base-url       "https://my.domain/"
                 :auto-validate? false}
  :server       {:http-port 8080
                 :mode      "dev"

--- a/src/clj/comimo/db/subscriptions.clj
+++ b/src/clj/comimo/db/subscriptions.clj
@@ -44,13 +44,13 @@
     (when-let [user-subs (call-sql "get_unsent_subscriptions" latest-time)]
       (doseq [{:keys [user_id email default_lang regions]} user-subs]
         (try
-          (let [regions (into-array String regions)
+          (let [regions     (into-array String regions)
                 {:keys [msg project-id]} (create-project! user_id
                                                           (str (if (= "en" default_lang) "Alert for " "Alerta para ")
                                                                latest-image)
                                                           regions
                                                           latest-image)
-                action (if project-id "Created" "Failed")
+                action      (if project-id "Created" "Failed")
                 project-url (str (get-base-url) "/collect?projectId=" project-id)]
             (when (= action "Created")
               (send-alert-mail email project-url default_lang)

--- a/src/clj/comimo/db/subscriptions.clj
+++ b/src/clj/comimo/db/subscriptions.clj
@@ -53,7 +53,7 @@
                 action      (if project-id "Created" "Failed")
                 project-url (str (get-base-url) "/collect?projectId=" project-id)]
             (when (= action "Created")
-              (send-alert-mail email project-url default_lang)
+              (send-alert-mail email project-url default_lang :type :html)
               (println "email sent to " email))
             (call-sql "log_email_alert" user_id action msg regions)
             (println "called log email alert sql")

--- a/src/clj/comimo/email.clj
+++ b/src/clj/comimo/email.clj
@@ -22,8 +22,8 @@
                :content body}]}))
 
 (defn send-mail [to-addresses cc-addresses bcc-addresses subject body content-type]
-  (let [mime                    {:text "text/plain"
-                                 :html "text/html"}
+  (let [mime                    {:text "text/plain; charset=UTF-8"
+                                 :html "text/html; charset=UTF-8"}
         {:keys [message error]} (send-postal to-addresses
                                              cc-addresses
                                              bcc-addresses

--- a/src/clj/comimo/email.clj
+++ b/src/clj/comimo/email.clj
@@ -69,7 +69,7 @@
         title {:en "CoMiMo: mine alert"
                :es "CoMiMo: alerta minera"}
         body  {:text {:en (format (str "Mine Alert\n\n"
-                                       "We have detected possible mining sites in the areas to which it is subscribed.\n\n"
+                                       "We have detected possible mining sites in the areas to which you are subscribed.\n\n"
                                        "You can see the new validations listed in CoMiMo here: %s\n\n"
                                        "To validate this information, go to the validation panel in the application or go directly to CoMiMo: %s&locale=en")
                                   (get-base-url)
@@ -82,9 +82,9 @@
                                   project-url)}
                :html {:en (format (str "<html><body>"
                                        "<h3>Mine Alert</h3>"
-                                       "<p>We have detected possible mining sites in the areas to which it is subscribed.</p>"
-                                       "<p>You can see the new validations listed in CoMiMo <a href='%s'>here.</a>.</p>"
-                                       "<p>To validate this information, go to the validation panel in the application or go directly to"
+                                       "<p>We have detected possible mining sites in the areas to which you are subscribed.</p>"
+                                       "<p>You can see the new validations listed in CoMiMo <a href='%s'>here</a>.</p>"
+                                       "<p>To validate this information, go to the validation panel in the application or go directly to "
                                        "<a href='%s&locale=en'>CoMiMo</a>.</p>"
                                        "</body></html>")
                                   (get-base-url)
@@ -93,7 +93,7 @@
                                        "<h3>¡Alerta!</h3>"
                                        "<p>Hemos detectado posibles sitios de explotación minera en las áreas a las cuales se encuentra suscrito.</p>"
                                        "<p>Puede visualizar estas áreas <a href='%s'>aquí</a>.</p>"
-                                       "<p>Para validar esta información, diríjase al panel de validación en la aplicación o acceda directamente a"
+                                       "<p>Para validar esta información, diríjase al panel de validación en la aplicación o acceda directamente a "
                                        "<a href='%s&locale=es'>CoMiMo</a>.</p>"
                                        "</body></html>")
                                   (get-base-url)


### PR DESCRIPTION
## Purpose
Fixes some small spacing and grammatical bugs with the email code. Adds UTF-8 encoding to emails to fix an issue where characters weren't showing up in some email clients.

## Related Issues

Closes SER-302

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

