### PR TITLE
SER-316 Add timeout to py-wrapper and cache GEE layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ classes/
 .DS_Store
 resources/public/js/
 .calva/
-
+.rebel_readline_history

--- a/src/clj/comimo/py_interop.clj
+++ b/src/clj/comimo/py_interop.clj
@@ -57,9 +57,23 @@
 (defn location-in-country [lat lng]
   (py-wrapper utils/locationInCountry lat lng))
 
-;; For now this isnt generic.
+;;; Image Cache
+
+(defonce image-max-age         (* 60 1000)) ; Once an hour
+(defonce image-cache           (atom nil))
+(defonce image-cache-timestamp (atom 0))
+
+(defn- image-cached? []
+  (and (< (- (System/currentTimeMillis) @image-cache-timestamp) image-max-age)
+       (seq @image-cache)))
+
+(defn- reset-image-cache! []
+    (reset! image-cache (py-wrapper utils/getImageList image-location)))
+
 (defn get-image-list []
-  (py-wrapper utils/getImageList image-location))
+  (when-not (image-cached?)
+    (reset-image-cache!))
+  @image-cache)
 
 ;;; Routes
 

--- a/src/clj/comimo/py_interop.clj
+++ b/src/clj/comimo/py_interop.clj
@@ -68,7 +68,8 @@
        (seq @image-cache)))
 
 (defn- reset-image-cache! []
-    (reset! image-cache (py-wrapper utils/getImageList image-location)))
+  (reset! image-cache-timestamp (System/currentTimeMillis))
+  (reset! image-cache (py-wrapper utils/getImageList image-location)))
 
 (defn get-image-list []
   (when-not (image-cached?)


### PR DESCRIPTION
## Purpose

Add caching to GEE layers and add add a three second timeout to the `py-wrapper` function.

## Related Issues

Closes SER-316

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
Layers should load normally and the website shouldn't crash :sweat_smile: 
