### PR TITLE
SER-309 Fix search functionality and improve UI

### DIFF
--- a/src/js/components/Search.jsx
+++ b/src/js/components/Search.jsx
@@ -13,14 +13,22 @@ import { useTranslation } from "react-i18next";
 import { visiblePanelAtom } from "../home";
 
 const SearchResults = styled.div`
+  background: var(--gray-3);
+  border-radius: 5px;
+  padding: 0.5rem;
+
   &:active {
-    background: #ddd;
+    background: var(--orange-4);
     cursor: pointer;
   }
 
   &:hover {
-    background: #eee;
+    background: var(--orange-4);
     cursor: pointer;
+  }
+
+  &:last-child {
+    margin-bottom: 15px;
   }
 `;
 
@@ -49,8 +57,7 @@ export default function Search({ theMap, featureNames, mapquestKey, isPanel }) {
   const { t } = useTranslation();
 
   const searchGeocode = () => {
-    const url =
-      URLS.MAPQUEST + "?key=" + mapquestKey + "&county=" + searchText + "&country=colombia";
+    const url = URLS.MAPQUEST + "?key=" + mapquestKey + "&location=" + searchText + ",Columbia";
     jsonRequest(url, null, "GET")
       .then((result) => {
         setGeoCodedSearch(
@@ -58,8 +65,7 @@ export default function Search({ theMap, featureNames, mapquestKey, isPanel }) {
             try {
               return (
                 l.adminArea1 === "CO" &&
-                featureNames[l.adminArea3.toUpperCase()][l.adminArea4.toUpperCase()] &&
-                !l.adminArea5 &&
+                featureNames[l.adminArea4.toUpperCase()][l.adminArea5.toUpperCase()] &&
                 !l.adminArea6
               );
             } catch (err) {
@@ -89,15 +95,16 @@ export default function Search({ theMap, featureNames, mapquestKey, isPanel }) {
             <SearchResults
               key={item.adminArea3}
               onClick={() => {
-                const state = item.adminArea3.toUpperCase();
-                const mun = item.adminArea4.toUpperCase();
+                const state = item.adminArea4.toUpperCase();
+                const mun = item.adminArea5.toUpperCase();
                 setSelectedL1(state);
                 setSelectedL2(mun);
                 fitMap(theMap, "bbox", featureNames[state][mun], t);
                 // We don't want to set the selected region on the header Search tool
                 !isPanel &&
                   setSelectedRegion(
-                    `mun_${item.adminArea3.toUpperCase()}_${item.adminArea4.toUpperCase()}`
+                    // adminArea4 is "county", adminArea5 is "city"
+                    `mun_${item.adminArea5.toUpperCase()}_${item.adminArea4.toUpperCase()}`
                   );
               }}
               style={{ display: "flex", flexDirection: "column" }}
@@ -105,7 +112,7 @@ export default function Search({ theMap, featureNames, mapquestKey, isPanel }) {
               <span>
                 <b>{item.adminArea1}</b>&nbsp;
                 <i>
-                  {item.adminArea4}, {item.adminArea3}
+                  {item.adminArea5}, {item.adminArea4}
                 </i>
               </span>
               <span>

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -91,7 +91,7 @@ export const URLS = {
   IMG_DATES: "get-image-names",
   LOGS: "get-log-list",
   NICFI_DATES: "get-nicfi-dates",
-  MAPQUEST: "https://open.mapquestapi.com/geocoding/v1/address",
+  MAPQUEST: "https://www.mapquestapi.com/geocoding/v1/address",
   PROJ_DATA: "get-project-by-id",
   PROJ_PLOTS: "get-project-plots",
   PREDICTIONS: "download-predictions",


### PR DESCRIPTION
## Purpose
Fixes the search functionality -- the Mapquest API endpoint changed. Also adds some nicer UI to the search functionality. 

## Related Issues

Closes SER-309

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Search > Search by Name

### Role

Visitor

### Steps

1. Click on the Search button on the home screen.
2. Enter a municipality name exactly as it's spelled (e.g. Abejorral).
3. Click the Go button or Enter.

### Desired Outcome

Click on the resulting pop up (which should be grey and yellow on hover). You should be taken on the map to that municipality.

---


## Screenshots
UI before:
![Screenshot from 2023-03-17 18-55-13](https://user-images.githubusercontent.com/40574170/226077864-b3260fc0-7c11-4019-8276-3744723e6740.png)


UI after (on hover):
![Screenshot from 2023-03-17 19-05-39](https://user-images.githubusercontent.com/40574170/226077869-7ad965ac-6a63-4196-afd4-92abf80768ab.png)


