### PR TITLE
SER-311 Add a new multi select component for selecting custom municipalities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ classes/
 resources/public/js/
 .calva/
 .rebel_readline_history
+.vscode/

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-i18next": "^11.18.5",
+    "react-select": "^5.7.2",
     "react-tabulator": "^0.18.1",
     "turf-extent": "^1.0.4"
   },

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -199,16 +199,6 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
           };
         })}
         ref={selectRef}
-        styles={{
-          menu: (baseStyles, state) => ({
-            ...baseStyles,
-            marginBottom: "0.5rem",
-          }),
-          menuPortal: (baseStyles, state) => ({
-            ...baseStyles,
-            marginBottom: "40px",
-          }),
-        }}
       />
     );
   };

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -2,13 +2,13 @@ import React, { useRef, useEffect, useState } from "react";
 import { useAtom, useAtomValue } from "jotai";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
+import Select from "react-select";
 
 import LoginMessage from "./LoginMessage";
 
 import Button from "../components/Button";
 import ToolCard from "../components/ToolCard";
 import ProjectCard from "../components/ProjectCard";
-import Select from "../components/Select";
 import TextInput from "../components/TextInput";
 import HeaderLabel from "../components/HeaderLabel";
 import { renderMessageBox } from "../components/Modal";
@@ -39,6 +39,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
   const [errorMsg, setErrorMsg] = useState(null);
   const [messageBox, setMessageBox] = useState(null);
   const msgRef = useRef(null);
+  const selectRef = useRef(null);
 
   const scrollToRef = (ref) => ref && ref.current.scrollIntoView({ behavior: "smooth" });
 
@@ -160,32 +161,55 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
 
   const renderCustomRegions = () => {
     const states = Object.keys(featureNames).sort();
+
+    const handleCloseSelect = () => {
+      selectRef.current.blur();
+    };
+
     return states.length === 0 ? (
       <option key="0" disabled>{`${t("validate.loading")}...`}</option>
     ) : (
-      <select
+      <Select
+        blurInputOnSelect={false} // to make sure the menu doesn't close on mobile select
+        className="basic-multi-select"
+        classNamePrefix="select"
+        closeMenuOnSelect={false}
+        defaultValue={customRegions.map((region) => {
+          // To match the convetion above, we use the value as "state_municipality"
+          // and the label as just the "municipality" (we split on the underscore)
+          return { value: region, label: region.split("_")[1] };
+        })}
         id="selectProjRegions"
-        multiple
-        onChange={() => null} // This is to squash the react warning
-        size="8"
-        style={{ width: "100%", float: "left", marginBottom: "10px" }}
-        value={customRegions}
-      >
-        {states.map((state) => (
-          <optgroup key={state} label={state}>
-            {Object.keys(featureNames[state])
-              .sort()
-              .map((mun) => {
-                const combined = state + "_" + mun;
-                return (
-                  <option key={mun} onClick={() => customSelect(combined)} value={combined}>
-                    {mun}
-                  </option>
-                );
-              })}
-          </optgroup>
-        ))}
-      </select>
+        isMulti
+        isSearchable={false}
+        onBlur={handleCloseSelect}
+        onChange={(e) => {
+          setCustomRegions(e.map((selection) => selection.value));
+        }}
+        // Because we're using a multi-select component, options need to be an array of objects.
+        // Here, each object is a different state where the label is the state and the options are all
+        // municipalities within that state. We use the convention "state_municipality" for value matching.
+        options={states.map((state) => {
+          const allMunicipalities = Object.keys(featureNames[state]).sort();
+          return {
+            label: state,
+            options: allMunicipalities.map((mun) => {
+              return { value: state + "_" + mun, label: mun };
+            }),
+          };
+        })}
+        ref={selectRef}
+        styles={{
+          menu: (baseStyles, state) => ({
+            ...baseStyles,
+            marginBottom: "0.5rem",
+          }),
+          menuPortal: (baseStyles, state) => ({
+            ...baseStyles,
+            marginBottom: "40px",
+          }),
+        }}
+      />
     );
   };
 
@@ -224,15 +248,25 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
             onChange={(e) => setProjectName(e.target.value)}
             value={projectName}
           />
+          <Label htmlFor="selectMineType">{`${t("validate.typeLabel")}:`}</Label>
           <Select
+            className="basic-single"
+            classNamePrefix="select"
+            defaultValue={{ value: mineType, label: t(`validate.${mineType}`) }}
             id="selectMineType"
-            label={`${t("validate.typeLabel")}:`}
-            onChange={(e) => setMineType(e.target.value)}
+            onChange={(e) => setMineType(e.value)}
             options={["pMines", "nMines", "cMines"].map((m) => ({
               value: m,
               label: t(`validate.${m}`),
             }))}
-            value={mineType}
+            styles={{
+              control: (baseStyles, state) => ({
+                ...baseStyles,
+                marginBottom: "0.5rem",
+                marginTop: "0.5rem",
+                fontSize: "1rem",
+              }),
+            }}
           />
           <Label>{`${t("validate.projectRegion")}:`}</Label>
           <label htmlFor="subscribed" style={{ marginTop: ".25rem", cursor: "pointer" }}>


### PR DESCRIPTION

## Purpose
Users were not able to select municipalities on mobile because of our multi select component. I tried for a while, but there was no working work-around. I thus reached for the `react-select` component, which has better UI and works on mobile.


## Related Issues

Closes SER-311

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Home > Create Project

### Role

User
### Steps


1. On both mobile and desktop, try to create a project with custom municipalities.

### Desired Outcome
The project should be created successfully with the selected municipalities.
---

## Screenshots

Desktop:
![Screenshot from 2023-03-24 18-07-44](https://user-images.githubusercontent.com/40574170/227674748-819cdb75-aa2e-4a66-ac7f-6b3293647fcd.png)
![Screenshot from 2023-03-24 18-07-59](https://user-images.githubusercontent.com/40574170/227674751-8c4c8184-9775-4e7e-9778-5c3da08a1ea9.png)


Mobile:
![336652447_1538367419986649_8929145570555052741_n](https://user-images.githubusercontent.com/40574170/227674764-316595b9-727c-4e66-9203-57c51aa7590d.jpg)



