### PR TITLE
COM-255: Disable map rotation and pitch to avoid confusing mobile users

### DIFF
--- a/src/js/collect/CollectMap.jsx
+++ b/src/js/collect/CollectMap.jsx
@@ -51,6 +51,13 @@ export default function CollectMap({ boundary, projectPlots, goToPlot, currentPl
         center: [lng, lat],
         zoom: zoom,
       });
+
+      // disable map rotation using right click + drag
+      map.dragRotate.disable();
+
+      // disable map rotation using touch rotation gesture
+      map.touchZoomRotate.disableRotation();
+
       map.on("load", () => mapOnLoad(map));
       setCollectMap(map);
     }

--- a/src/js/home/HomeMap.jsx
+++ b/src/js/home/HomeMap.jsx
@@ -52,6 +52,12 @@ export default function HomeMap({}) {
         zoom: zoom,
       });
 
+      // // disable map rotation using right click + drag
+      map.dragRotate.disable();
+
+      // // disable map rotation using touch rotation gesture
+      map.touchZoomRotate.disableRotation();
+
       map.on("load", () => {
         addLayerSources(map, [...availableLayers].reverse());
         map.resize();


### PR DESCRIPTION
## Purpose
Disables map rotation and pitch to avoid confusing mobile users

## Related Issues
Closes [COM-255](https://sig-gis.atlassian.net/browse/COM-255)


[COM-255]: https://sig-gis.atlassian.net/browse/COM-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ