### PR TITLE
COM-259: On the validation panel, make the project name input optional

### DIFF
--- a/resources/public/locales/en.json
+++ b/resources/public/locales/en.json
@@ -274,6 +274,7 @@
     "verifying": "Verifying email"
   },
   "validate": {
+    "autoGenerate": "Auto Generate",
     "cMines": "Confirmed mines",
     "closeConfirm": "Are you sure you want to close this project? Closing the project means you will no longer be able to validate the predictions unless you set up another project.",
     "closeTitle": "Close Project",
@@ -282,6 +283,7 @@
     "createProject": "Create a New Project",
     "createTitle": "Create Project",
     "createdLabel": "Created date",
+    "customProjectName": "Custom Project Name",
     "customRadio": "Custom municipalities",
     "errorClose": "Could not close project.",
     "errorDate": "Please select a date.",
@@ -302,7 +304,8 @@
     "pMines": "Current predictions",
     "predictionLabel": "Prediction date",
     "projectExists": "This project already exists. Make sure that this project is not a duplicate of any existing projects.",
-    "projectName": "Enter Project Name",
+    "projectName": "Project Name",
+    "projectNameLabel": "Enter Project Name",
     "projectRegion": "Select Municipalities",
     "projectWithNoPlots": "Error creating project with no plots. Make sure the municipalities in this project have plots.",
     "regionsLabel": "Municipalities",

--- a/resources/public/locales/es.json
+++ b/resources/public/locales/es.json
@@ -274,6 +274,7 @@
     "verifying": "Verificando email"
   },
   "validate": {
+    "autoGenerate": "Generar automáticamente",
     "cMines": "Minas confirmadas",
     "closeConfirm": "¿Estás seguro/a de que quieres cerrar este proyecto? Al cerrar el proyecto ya no podrás validar las predicciones a menos que crees uno nuevo.",
     "closeTitle": "Cerrar Proyecto",
@@ -282,6 +283,7 @@
     "createProject": "Crea un Nuevo Proyecto",
     "createTitle": "Crear Proyecto",
     "createdLabel": "Fecha de creación",
+    "customProjectName": "Personaliza el Nombre del Proyecto",
     "customRadio": "Municipios personalizados",
     "errorClose": "No se pudo cerrar el proyecto.",
     "errorDate": "Seleccionar una fecha.",
@@ -302,7 +304,8 @@
     "pMines": "Predicciones actuales",
     "predictionLabel": "Fecha de predicción",
     "projectExists": "Ya existe un proyecto con esta configuración.",
-    "projectName": "Ingresa el Nombre del Proyecto",
+    "projectName": "Nombre del Proyecto",
+    "projectNameLabel": "Ingresa el Nombre del Proyecto",
     "projectRegion": "Selecciona los Municipios del Proyecto",
     "projectWithNoPlots": "No hay predicciones en los municipios seleccionados.",
     "regionsLabel": "Municipios",

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -234,7 +234,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
             {t("validate.createProject")}
           </HeaderLabel>
           <Label>{`${t("validate.projectRegion")}:`}</Label>
-          <Label>Project Name</Label>
+          <Label>{t("validate.projectNameLabel")}</Label>
           <label htmlFor="autoProjectName" style={{ marginTop: ".25rem", cursor: "pointer" }}>
             <input
               id="autoProjectName"
@@ -243,7 +243,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
               onChange={() => setAutoProjectName(true)}
               type="radio"
             />
-            Auto Generate
+            {t("validate.autoGenerate")}
           </label>
           <label htmlFor="customProjectName" style={{ marginTop: ".25rem", cursor: "pointer" }}>
             <input
@@ -254,7 +254,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
               type="radio"
               value={false}
             />
-            Custom Project Name
+            {t("validate.customProjectName")}
           </label>
           {!autoProjectName && (
             <TextInput

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -314,9 +314,6 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
                 ? customRegions.map((x) => "mun_" + x).join("_")
                 : customProjectName;
               const _dataLayer = selectedDates?.[mineType] || "2022-01-01-N";
-
-              debugger;
-
               createProject(_projectName, _dataLayer);
             }}
           >{`${t("validate.createButton")} ${selectedDates?.[mineType]}`}</Button>

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -32,7 +32,8 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
   const [showModal, setShowModal] = useAtom(showModalAtom);
   const username = useAtomValue(usernameAtom);
   const [projects, setProjects] = useState([]);
-  const [projectName, setProjectName] = useState("");
+  const [autoProjectName, setAutoProjectName] = useState(true);
+  const [customProjectName, setCustomProjectName] = useState("");
   const [regionType, setRegionType] = useState(1);
   const [customRegions, setCustomRegions] = useState([]);
   const [mineType, setMineType] = useState("pMines");
@@ -62,7 +63,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
     setProjects(res || []);
   };
 
-  const checkProjectErrors = (dataLayer, selected, projectName, projects, type) => {
+  const checkProjectErrors = (projectName, dataLayer, selected, projects, type) => {
     const errors = [
       !dataLayer && t("validate.errorDate"),
       selected.length === 0 &&
@@ -73,7 +74,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
     return errors.length === 0 || setErrorMsg(errors.join("\n\n"));
   };
 
-  const createProject = (dataLayer) => {
+  const createProject = (projectName, dataLayer) => {
     setErrorMsg(null);
     const selectedArr = regionType === 1 ? subscribedList : customRegions.map((x) => "mun_" + x);
     const regions = selectedArr
@@ -87,7 +88,7 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
       .replace("{%name}", projectName)
       .replace("{%region}", regions);
 
-    if (checkProjectErrors(dataLayer, selectedArr, projectName, projects, regionType)) {
+    if (checkProjectErrors(projectName, dataLayer, selectedArr, projects, regionType)) {
       showAlert({
         title: t("validate.createTitle"),
         body: question,
@@ -232,12 +233,37 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
           >
             {t("validate.createProject")}
           </HeaderLabel>
-          <TextInput
-            id="projectName"
-            label={`${t("validate.projectName")}:`}
-            onChange={(e) => setProjectName(e.target.value)}
-            value={projectName}
-          />
+          <Label>{`${t("validate.projectRegion")}:`}</Label>
+          <Label>Project Name</Label>
+          <label htmlFor="autoProjectName" style={{ marginTop: ".25rem", cursor: "pointer" }}>
+            <input
+              id="autoProjectName"
+              checked={autoProjectName}
+              name="projectName"
+              onChange={() => setAutoProjectName(true)}
+              type="radio"
+            />
+            Auto Generate
+          </label>
+          <label htmlFor="customProjectName" style={{ marginTop: ".25rem", cursor: "pointer" }}>
+            <input
+              id="customProjectName"
+              checked={!autoProjectName}
+              name="projectName"
+              onChange={() => setAutoProjectName(false)}
+              type="radio"
+              value={false}
+            />
+            Custom Project Name
+          </label>
+          {!autoProjectName && (
+            <TextInput
+              id="projectName"
+              label={`${t("validate.projectName")}:`}
+              onChange={(e) => setCustomProjectName(e.target.value)}
+              value={customProjectName}
+            />
+          )}
           <Label htmlFor="selectMineType">{`${t("validate.typeLabel")}:`}</Label>
           <Select
             className="basic-single"
@@ -283,7 +309,16 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
           {regionType === 2 && renderCustomRegions()}
           <Button
             extraStyle={{ marginTop: "1rem" }}
-            onClick={() => createProject(selectedDates?.[mineType] || "2022-01-01-N")}
+            onClick={() => {
+              const _projectName = autoProjectName
+                ? customRegions.map((x) => "mun_" + x).join("_")
+                : customProjectName;
+              const _dataLayer = selectedDates?.[mineType] || "2022-01-01-N";
+
+              debugger;
+
+              createProject(_projectName, _dataLayer);
+            }}
           >{`${t("validate.createButton")} ${selectedDates?.[mineType]}`}</Button>
           <div ref={msgRef}>
             {errorMsg && (

--- a/src/js/home/ValidatePanel.jsx
+++ b/src/js/home/ValidatePanel.jsx
@@ -310,9 +310,16 @@ export default function ValidatePanel({ subscribedList, featureNames, selectedDa
           <Button
             extraStyle={{ marginTop: "1rem" }}
             onClick={() => {
-              const _projectName = autoProjectName
-                ? customRegions.map((x) => "mun_" + x).join("_")
-                : customProjectName;
+              let _projectName;
+              if (autoProjectName) {
+                const comprisingStates = Array.from(
+                  new Set(customRegions.map((r) => r.split("_")[0]))
+                );
+                const today = new Date().toISOString().substring(0, 10);
+                _projectName = comprisingStates.join("_") + "_" + today;
+              } else {
+                _projectName = customProjectName;
+              }
               const _dataLayer = selectedDates?.[mineType] || "2022-01-01-N";
               createProject(_projectName, _dataLayer);
             }}


### PR DESCRIPTION
  ## Purpose
To make the project name input optional, an auto project name generation function was added to the validation panel.
As specified on the ticket, the function gathers the set of selected municipalities and concatenates the names with the following pattern: `mun_MUN1_mun_MUN2_mun_MUNNth`

- Project auto generation is set as the default
- A radio group was added to give the user the ability to edit a custom
  project name if desired.

## Related Issues
  Closes [COM-259](https://sig-gis.atlassian.net/browse/COM-259)

![image](https://github.com/sig-gis/comimo/assets/1130619/7056cf44-2c07-41fe-a2c5-9a1d16bb9ab0)

![image](https://github.com/sig-gis/comimo/assets/1130619/9e6d9f4e-bacf-49fb-9188-04bf1e562990)


[COM-259]: https://sig-gis.atlassian.net/browse/COM-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


