### PR TITLE
COM-261: Bugfix to avoid timeout error when downloading data

### DIFF
--- a/src/clj/comimo/py_interop.clj
+++ b/src/clj/comimo/py_interop.clj
@@ -1,17 +1,18 @@
 (ns comimo.py-interop
-  (:require [clojure.string :as str]
-            [libpython-clj2.require :refer [require-python]]
-            [libpython-clj2.python  :refer [py. get-attr ->jvm]]
+  (:require
+            [clojure.string             :as str]
+            [comimo.views               :refer [data-response]]
+            [libpython-clj2.python      :refer [py. get-attr ->jvm]]
             [libpython-clj2.python.copy :refer [*item-tuple-cutoff*]]
-            [triangulum.type-conversion :as tc]
-            [triangulum.logging :refer [log-str]]
-            [triangulum.config :refer [get-config]]
-            [comimo.views :refer [data-response]]
-            [triangulum.database :refer [call-sql]]))
+            [libpython-clj2.require     :refer [require-python]]
+            [triangulum.config          :refer [get-config]]
+            [triangulum.database        :refer [call-sql]]
+            [triangulum.logging         :refer [log-str]]
+            [triangulum.type-conversion :as tc]))
 
 ;;; Constants
 
-(def ^:private max-age (* 24 60 1000)) ; Once a day
+(def ^:private max-age (* 24 60 60 1000)) ; Once a day
 (def point-location "users/comimoapp/ValidationPoints")
 (def image-location "users/comimoapp/Images")
 
@@ -57,7 +58,7 @@
                    (str/join ": "))}))
 
 (defn- py-wrapper [py-fn & params]
-  (run-with-timeout 3000
+  (run-with-timeout 6000
                     (check-initialized)
                     (binding [*item-tuple-cutoff* 0]
                       (try (->jvm (apply py-fn params))
@@ -76,7 +77,7 @@
 
 ;;; Image Cache
 
-(defonce image-max-age         (* 60 1000)) ; Once an hour
+(defonce image-max-age         (* 60 60 1000)) ; Once an hour
 (defonce image-cache           (atom nil))
 (defonce image-cache-timestamp (atom 0))
 


### PR DESCRIPTION
  ## Purpose
  The fix increases the timeout setting to avoid hitting the timeout error.

  ## Related Issues
  Closes [COM-261](https://sig-gis.atlassian.net/browse/COM-261)


[COM-261]: https://sig-gis.atlassian.net/browse/COM-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ