### PR TITLE
COM-257: Add a users list data download option to the admin page

### DIFF
--- a/resources/public/locales/en.json
+++ b/resources/public/locales/en.json
@@ -14,9 +14,11 @@
     "noData": "There is no data available for this month. Please try another month.",
     "predictions": "Collected predictions",
     "reload": "Reload",
+    "reportingMonth": "Reporting Month",
     "role": "Role",
     "save": "Save",
     "selectDate": "Select Date...",
+    "toggleUsersDownloadView": "Toggle Download View",
     "userMines": "User reported mines",
     "username": "Username",
     "users": "Users"

--- a/resources/public/locales/en.json
+++ b/resources/public/locales/en.json
@@ -2,6 +2,8 @@
   "admin": {
     "downloadCSV": "Download CSV",
     "downloadJSON": "Download JSON",
+    "downloadView": "Download View",
+    "editView": "Edit View",
     "email": "Email",
     "emptyLogs": "There are no logs available at this time.",
     "emptyTable": "Please select a reporting month and click 'Load' to view results.",
@@ -18,7 +20,6 @@
     "role": "Role",
     "save": "Save",
     "selectDate": "Select Date...",
-    "toggleUsersDownloadView": "Toggle Download View",
     "userMines": "User reported mines",
     "username": "Username",
     "users": "Users"

--- a/resources/public/locales/es.json
+++ b/resources/public/locales/es.json
@@ -14,9 +14,11 @@
     "noData": "No hay datos disponibles para este mes. Por favor, intente con un mes diferente.",
     "predictions": "Predicciones recopiladas",
     "reload": "Recargar",
+    "reportingMonth": "Mes de Informe",
     "role": "Posición",
     "save": "Guardar",
     "selectDate": "Seleccione Fecha...",
+    "toggleUsersDownloadView": "Alternar vista de descarga",
     "userMines": "Minas reportadas por usuarios",
     "username": "Nombre de usuario",
     "users": "Usuarios"

--- a/resources/public/locales/es.json
+++ b/resources/public/locales/es.json
@@ -2,6 +2,8 @@
   "admin": {
     "downloadCSV": "Descargar CSV",
     "downloadJSON": "Descargar JSON",
+    "downloadView": "Vista de descarga",
+    "editView": "Vista de Editar",
     "email": "Email",
     "emptyLogs": "No hay registros disponibles en este momento.",
     "emptyTable": "Seleccione un mes y haga clic en 'Carga' para ver los resultados.",
@@ -18,7 +20,6 @@
     "role": "Posición",
     "save": "Guardar",
     "selectDate": "Seleccione Fecha...",
-    "toggleUsersDownloadView": "Alternar vista de descarga",
     "userMines": "Minas reportadas por usuarios",
     "username": "Nombre de usuario",
     "users": "Usuarios"

--- a/src/js/admin.jsx
+++ b/src/js/admin.jsx
@@ -80,7 +80,13 @@ const EmptyMessage = styled.div`
 `;
 
 function makeAdminTableComponent(dateDataURL, columnFields, tableRefDownloadURL) {
-  return ({ addCollectedData, availableDates, collectedData, renderButtons }) => {
+  return ({
+    addCollectedData,
+    availableDates,
+    collectedData,
+    renderButtons,
+    hideReportingPeriod = false,
+  }) => {
     // STATE
     const [selectedDate, setSelectedDate] = useState(-1);
     const [tableRef, setTableRef] = useState(null);
@@ -108,7 +114,7 @@ function makeAdminTableComponent(dateDataURL, columnFields, tableRefDownloadURL)
 
     return (
       <>
-        {availableDates.length > 1 && (
+        {!hideReportingPeriod && (
           <div>
             <label htmlFor="project-date">Reporting month</label>
             <select
@@ -131,7 +137,6 @@ function makeAdminTableComponent(dateDataURL, columnFields, tableRefDownloadURL)
             <Button
               onClick={() => {
                 loadDateData(selectedDate);
-                debugger;
               }}
               isDisabled={selectedDate === -1}
             >
@@ -224,14 +229,11 @@ function AdminContent() {
   const todayDate = new Date();
   const [availableDates, setAvailableDates] = useState({ predictions: [], userMines: [] });
   const [collectedData, setCollectedData] = useState({});
-  const {
-    predictions,
-    userMines,
-    users = [new Date().toISOString().substring(0, 10)],
-  } = availableDates;
+  const { predictions, userMines } = availableDates;
   const addCollectedData = (dataLayer, data) =>
     setCollectedData({ ...collectedData, [dataLayer]: data });
   const [filterStr, setFilterStr] = useState("");
+  const [showUsersDownloadView, setShowUsersDownloadView] = useState(false);
 
   const { t } = useTranslation();
   useEffect(() => {
@@ -309,39 +311,6 @@ function AdminContent() {
   };
 
   // const renderUsers = () =>
-  //   userList.filter((row) => isRowIncluded(row)).map(renderUserRow).length ? (
-  //     <>
-  //       <Filter
-  //         onChange={(e) => setFilterStr(e.target.value)}
-  //         placeholder="Filter"
-  //         value={filterStr}
-  //       />
-  //       <GridSection>
-  //         {renderUserRow({
-  //           userId: t("admin.id"),
-  //           username: t("admin.username"),
-  //           email: t("admin.email"),
-  //           role: t("admin.role"),
-  //         })}
-  //         {userList.filter((row) => isRowIncluded(row)).map(renderUserRow)}
-  //       </GridSection>
-  //       <div style={{ margin: "1rem", display: "flex" }}>
-  //         <div style={{ display: "flex", flexGrow: "1" }} />
-  //         <Button onClick={updateUserRoles} isDisabled={!roleChanged}>
-  //           {t("admin.save")}
-  //         </Button>
-  //       </div>
-  //     </>
-  //   ) : (
-  //     <>
-  //       <Filter
-  //         onChange={(e) => setFilterStr(e.target.value)}
-  //         placeholder="Filter"
-  //         value={filterStr}
-  //       />
-  //       <EmptyMessage>{t("admin.emptyUsers")}</EmptyMessage>
-  //     </>
-  //   );
 
   const renderLogRow = ({ jobTime, username, finishStatus, finishMessage }) => (
     <GridRow
@@ -417,13 +386,63 @@ function AdminContent() {
     />
   );
 
+  const renderEditUsers = () =>
+    userList.filter((row) => isRowIncluded(row)).map(renderUserRow).length ? (
+      <>
+        <Filter
+          onChange={(e) => setFilterStr(e.target.value)}
+          placeholder="Filter"
+          value={filterStr}
+        />
+        <GridSection>
+          {renderUserRow({
+            userId: t("admin.id"),
+            username: t("admin.username"),
+            email: t("admin.email"),
+            role: t("admin.role"),
+          })}
+          {userList.filter((row) => isRowIncluded(row)).map(renderUserRow)}
+        </GridSection>
+        <div style={{ margin: "1rem", display: "flex" }}>
+          <div style={{ display: "flex", flexGrow: "1" }} />
+          <Button onClick={updateUserRoles} isDisabled={!roleChanged}>
+            {t("admin.save")}
+          </Button>
+        </div>
+      </>
+    ) : (
+      <>
+        <Filter
+          onChange={(e) => setFilterStr(e.target.value)}
+          placeholder="Filter"
+          value={filterStr}
+        />
+        <EmptyMessage>{t("admin.emptyUsers")}</EmptyMessage>
+      </>
+    );
+
   const renderUsers = () => (
-    <Users
-      addCollectedData={addCollectedData}
-      availableDates={users}
-      collectedData={collectedData}
-      renderButtons={renderButtons}
-    />
+    <div>
+      <Button
+        extraStyle={{ marginBottom: "9px" }}
+        onClick={() => {
+          setShowUsersDownloadView(!showUsersDownloadView);
+        }}
+      >
+        {t("admin.toggleUsersDownloadView")}
+      </Button>
+      {showUsersDownloadView ? (
+        <Users
+          addCollectedData={addCollectedData}
+          availableDates={[new Date().toISOString().substring(0, 10)]}
+          collectedData={collectedData}
+          renderButtons={renderButtons}
+          hideReportingPeriod={true}
+        />
+      ) : (
+        renderEditUsers()
+      )}
+    </div>
   );
 
   return (

--- a/src/js/admin.jsx
+++ b/src/js/admin.jsx
@@ -233,7 +233,7 @@ function AdminContent() {
   const addCollectedData = (dataLayer, data) =>
     setCollectedData({ ...collectedData, [dataLayer]: data });
   const [filterStr, setFilterStr] = useState("");
-  const [showUsersDownloadView, setShowUsersDownloadView] = useState(false);
+  const [downloadViewActive, setDownloadViewActive] = useState(false);
 
   const { t } = useTranslation();
   useEffect(() => {
@@ -353,6 +353,17 @@ function AdminContent() {
       </>
     );
 
+  const renderUsersViewToggle = () => (
+    <Button
+      extraStyle={{ marginRight: "8px" }}
+      onClick={() => {
+        setDownloadViewActive(!downloadViewActive);
+      }}
+    >
+      {t(downloadViewActive ? "admin.editView" : "admin.downloadView")}
+    </Button>
+  );
+
   const renderButtons = (downloadData) => (
     <div
       style={{
@@ -361,6 +372,7 @@ function AdminContent() {
         width: "100%",
       }}
     >
+      {renderUsersViewToggle()}
       <Button onClick={() => downloadData("csv")} extraStyle={{ marginRight: "0.5rem" }}>
         {t("admin.downloadCSV")}
       </Button>
@@ -404,10 +416,12 @@ function AdminContent() {
           {userList.filter((row) => isRowIncluded(row)).map(renderUserRow)}
         </GridSection>
         <div style={{ margin: "1rem", display: "flex" }}>
-          <div style={{ display: "flex", flexGrow: "1" }} />
-          <Button onClick={updateUserRoles} isDisabled={!roleChanged}>
-            {t("admin.save")}
-          </Button>
+          <div style={{ display: "flex", justifyContent: "flex-end", flexGrow: "1" }}>
+            {renderUsersViewToggle()}
+            <Button onClick={updateUserRoles} isDisabled={!roleChanged}>
+              {t("admin.save")}
+            </Button>
+          </div>
         </div>
       </>
     ) : (
@@ -422,16 +436,8 @@ function AdminContent() {
     );
 
   const renderUsers = () => (
-    <div>
-      <Button
-        extraStyle={{ marginBottom: "9px" }}
-        onClick={() => {
-          setShowUsersDownloadView(!showUsersDownloadView);
-        }}
-      >
-        {t("admin.toggleUsersDownloadView")}
-      </Button>
-      {showUsersDownloadView ? (
+    <>
+      {downloadViewActive ? (
         <Users
           addCollectedData={addCollectedData}
           availableDates={[new Date().toISOString().substring(0, 10)]}
@@ -442,7 +448,7 @@ function AdminContent() {
       ) : (
         renderEditUsers()
       )}
-    </div>
+    </>
   );
 
   return (


### PR DESCRIPTION
  ## Purpose
  Add a users data download option.  The admin page presently provides that functionality when selecting either the "Collected predictions" or "User reported mines" options. The changes reuse the behavior to download data with the "react-tabulator" module.

  ## Related Issues
  Closes [COM-257](https://sig-gis.atlassian.net/browse/COM-257)

  ## Screenshots, Etc.
![image](https://github.com/sig-gis/comimo/assets/1130619/020d8442-a63a-46f3-9cb7-8136405a4daa)

[COM-257]: https://sig-gis.atlassian.net/browse/COM-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ