### PR TITLE
COM-276 Add/Fix downloadURL in CSV/KML format (supporting the new vector laye…

### DIFF
--- a/src/clj/comimo/py_interop.clj
+++ b/src/clj/comimo/py_interop.clj
@@ -58,7 +58,7 @@
                    (str/join ": "))}))
 
 (defn- py-wrapper [py-fn & params]
-  (run-with-timeout 6000
+  (run-with-timeout 60000
                     (check-initialized)
                     (binding [*item-tuple-cutoff* 0]
                       (try (->jvm (apply py-fn params))
@@ -153,9 +153,9 @@
                         ""
                         (let [{:keys [source line fill]} opts]
                           (py-wrapper utils/getVectorUrl
-                            (if data-layer (str source "/" data-layer) source)
-                            line
-                            fill)))))))
+                                      (if data-layer (str source "/" data-layer) source)
+                                      line
+                                      fill)))))))
 
 (defn get-download-url [{:keys [params]}]
   (let [{:keys [region dataLayer]} params]
@@ -202,3 +202,4 @@
                            [v (let [{:keys [source source-base info-cols]} (get vector-layers v)]
                                 (py-wrapper utils/vectorPointOverlaps source lat lng info-cols))]))
                         (into {})))))
+

--- a/src/js/home/DownloadPanel.jsx
+++ b/src/js/home/DownloadPanel.jsx
@@ -31,6 +31,7 @@ export default function DownloadPanel({ active, featureNames, mapquestKey, selec
 
   const [clipOption, setClipOption] = useState(1);
   const [downloadURL, setDownloadURL] = useState(false);
+  const [format, setFormat] = useState("CSV");
   const [fetching, setFetching] = useState(false);
   const [mineType, setMineType] = useState("cMines");
 
@@ -41,18 +42,27 @@ export default function DownloadPanel({ active, featureNames, mapquestKey, selec
 
     processModal(
       () =>
-        jsonRequest(URLS.GET_DL_URL, {
+        jsonRequest("get-download-url", {
           region,
           dataLayer: selectedDates[mineType],
         })
           .then((resp) => {
-            setDownloadURL([region, selectedDates[mineType], resp]);
+            setDownloadURL({
+              region,
+              alertsLayer: selectedDates[mineType],
+              csvURL: resp.csvUrl,
+              kmlURL: resp.kmlUrl,
+            });
           })
           .catch((err) => {
             console.error(err);
           }),
       setShowModal
     );
+  };
+
+  const handleFormatChange = (event) => {
+    setFormat(event.target.value);
   };
 
   return (
@@ -126,21 +136,41 @@ export default function DownloadPanel({ active, featureNames, mapquestKey, selec
           <p>{`${t("download.fetching")}...`}</p>
         ) : (
           downloadURL &&
-          downloadURL[0] && (
-            <p>
+          downloadURL.region && (
+            <div>
+              <div style={{ display: "flex" }}>
+                <label style={{ display: "inline-block" }}>
+                  <input
+                    type="radio"
+                    value="CSV"
+                    checked={format === "CSV"}
+                    onChange={handleFormatChange}
+                  />
+                  CSV
+                </label>
+                <label style={{ display: "inline-block" }}>
+                  <input
+                    type="radio"
+                    value="KML"
+                    checked={format === "KML"}
+                    onChange={handleFormatChange}
+                  />
+                  KML
+                </label>
+              </div>
               <span>
-                <a href={downloadURL[2]}>
+                <a href={format === "CSV" ? downloadURL.csvURL : downloadURL.kmlURL}>
                   {`${t("download.clickHere")}` +
                     ` ${
-                      downloadURL[0] === "all"
+                      downloadURL.region === "all"
                         ? t("download.completeData")
-                        : t("download.munData") + downloadURL[0].split("_").slice(1).join(", ")
+                        : t("download.munData") + downloadURL.region.split("_").slice(1).join(", ")
                     }` +
                     ` ${t("download.prep")}` +
-                    ` ${downloadURL[1]}.`}
+                    ` ${downloadURL.alertsLayer}.`}
                 </a>
               </span>
-            </p>
+            </div>
           )
         )}
       </div>


### PR DESCRIPTION
Allow to download the alerts in CSV or KML layer (after selecting the date in filter and the regions and layer type)

<img width="715" alt="Screenshot 2023-11-05 at 2 31 51 PM" src="https://github.com/sig-gis/comimo/assets/8908139/14ddc5a3-7b0e-4ec1-8220-e42e3b3a2a7e">
