### PR TITLE
Fix mining alerts detection popup

### DIFF
--- a/src/clj/comimo/py_interop.clj
+++ b/src/clj/comimo/py_interop.clj
@@ -193,13 +193,15 @@
 
 (defn get-info [{:keys [params]}]
   (let [visible-layers (:visibleLayers params)
-        mine-dates     (:dates params)
+        alert-dates    (:dates params)
         lat            (tc/val->double (:lat params))
         lng            (tc/val->double (:lng params))]
     (data-response (->> visible-layers
                         (pmap
                          (fn [v]
-                           [v (let [{:keys [source source-base info-cols]} (get vector-layers (keyword v))]
-                                (py-wrapper utils/vectorPointOverlaps source lat lng info-cols))]))
+                           [v (let [layer (keyword v)
+                                    {:keys [source source-base info-cols]} (get vector-layers layer)]
+                                (if (#{:cMines :nMines :pMines} layer)
+                                  (py-wrapper utils/mineExists (str source "/" (alert-dates layer)) lat lng)
+                                  (py-wrapper utils/vectorPointOverlaps source lat lng info-cols)))]))
                         (into {})))))
-

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -70,6 +70,11 @@ def getDownloadURL(source, region):
        "kmlUrl": urlKml
    }
 
+def mineExists(source, lat, lon):
+    point = ee.Geometry.Point(lon, lat)
+    mine = ee.FeatureCollection(source).geometry()
+    return point.intersects(mine).getInfo()
+
 def vectorPointOverlaps(source, lat, lon, cols):
     try:
         point = ee.Geometry.Point(lon, lat)


### PR DESCRIPTION
Check if location (lat,lng) when part of layer is active to show information

<img width="731" alt="image" src="https://github.com/sig-gis/comimo/assets/8908139/5c503553-2893-4cdf-9e56-845fe84c8e5b">
