### PR TITLE
COM-285: Upgrade earthengine-api and other CoMiMo dependencies to resolve errors caused by GEE requests to v1alpha of earthengine.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,10 @@
 {:paths   ["src/clj" "resources" "dist"]
 
- :deps    {clj-http/clj-http         {:mvn/version "3.10.3"}
-           clj-python/libpython-clj  {:mvn/version "2.003"}
+ :deps    {cider/cider-nrepl         {:mvn/version "0.30.0"}
+           clj-http/clj-http         {:mvn/version "3.12.3"}
+           clj-python/libpython-clj  {:mvn/version "2.020"}
            org.clojure/clojure       {:mvn/version "1.11.1"}
-           org.clojure/data.json     {:mvn/version "1.0.0"}
+           org.clojure/data.json     {:mvn/version "2.4.0"}
            ring/ring                 {:mvn/version "1.8.2"}
            sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
                                       :git/sha "4aab4f9b6af8a7af1814c235f5709a27eb38f2c6"}}
@@ -23,7 +24,7 @@
                                           "-e" "(require,'comimo.routing)"]
                               :jvm-opts  ["--add-modules=jdk.incubator.foreign"
                                           "--enable-native-access=ALL-UNNAMED"]}
-           :check-deps       {:deps      {com.github.liquidz/antq {:mvn/version "2.5.1109"}}
+           :check-deps       {:deps      {com.github.liquidz/antq {:mvn/version "RELEASE"}}
                               :main-opts ["-m" "antq.core"]}
-           :nrepl-client     {:deps      {nrepl/nrepl {:mvn/version "0.9.0"}}
+           :nrepl-client     {:deps      {nrepl/nrepl {:mvn/version "1.0.0"}}
                               :main-opts ["-m" "nrepl.cmdline" "--connect" "--host" "127.0.0.1" "--port" "5555"]}}}


### PR DESCRIPTION
## Purpose
Resolve errors found when downloading confirmed layer data.

The `earthengine-api` depedency was outdated and requests made with it would call out to the outdated `v1alpha` version of the GEE API.

Resolution: `pip install --upgrade earthengine-api` on the host running the CoMiMo server.

Adds `deps.edn` updates.

## Related Issues
Closes [COM-285](https://sig-gis.atlassian.net/browse/COM-285)


[COM-285]: https://sig-gis.atlassian.net/browse/COM-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ