### PR TITLE
COM-301: Bugfix: Fix issue with retrieving all nicfi dates

### DIFF
--- a/src/clj/comimo/proxy.clj
+++ b/src/clj/comimo/proxy.clj
@@ -22,7 +22,7 @@
 ;;; Fill cache
 
 (defn nicfi-dates []
-  (as-> (client/get (str "https://api.planet.com/basemaps/v1/mosaics?api_key=" (get-config ::nicfi-key))) $
+  (as-> (client/get (str "https://api.planet.com/basemaps/v1/mosaics?_page_size=150&api_key=" (get-config ::nicfi-key))) $
     (:body $)
     (json/read-str $ :key-fn keyword)
     (:mosaics $)


### PR DESCRIPTION
## Purpose

NICFI dates for 2024 were missing, this PR solves the issue.
Due to NICFI contract ending in 2024, only a _page_size was added to retrieve the rest of the information

## Related Issues

Closes COM-301

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Validation > Imagery > nicfi dates

### Role

User

### Steps

1. Select Planet NICFI as imagery
2. Select a 2024 date
3. check if it displays the imagery
