### PR TITLE
COM-305 Fix issue with download URL

### DIFF
--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -59,11 +59,11 @@ def getDownloadURL(source, region):
    urlCsv = intersectFc.getDownloadURL(**{
        "selectors": ["coordinates"],
        "filetype": "CSV",
-       "filename": source[32:]
+       "filename": source[53:]
    })
    urlKml = intersectFc.getDownloadURL(**{
        "filetype": "KML",
-       "filename": source[32:]
+       "filename": source[53:]
    })
 
    return {


### PR DESCRIPTION
Basically the "download url" function depends on the data path name and since we changed the data paths recently, the function broke

## Purpose

Changed string slice start so that the source (alert data path) is retrieved properly

## Related Issues

Closes COM-305

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `SER-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

Tested here only: https://colab.research.google.com/drive/1DcK0niNBaM3ZAvk6Tj1VJFaiSdD3AtHx?usp=sharing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Account, Home, Subscriptions, Stats, Validation, Reporting, and Admin. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

Steps to reproduce are outlined in the description of the Jira ticket

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
